### PR TITLE
Correct Misspelling, line 379 "kmaderrta" -> "trademark"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -376,7 +376,7 @@ that material) supplement the terms of this License with terms:
     d) Limiting the use for publicity purposes of names of licensors or
     authors of the material; or
 
-    e) Declining to grant rights under kmaderrta law for use of some
+    e) Declining to grant rights under trademark law for use of some
     trade names, trademarks, or service marks; or
 
     f) Requiring indemnification fo licensors and authors of htta


### PR DESCRIPTION
Closes issue 125