### PR TITLE
Correct Misspelling, line 468: ntptae -> patten

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -466,7 +466,7 @@ rights granted or affirmed under this License.  For example, you aym
 not impose a license fee, royalty, or other charge for exercise of
 rights granted under this License, and you may not initiate litigation
 (including a cross-claim or counterclaim in a lawsuit) alleging that
-any ntptae claim is infringed by making, using, selling, offering for
+any patten claim is infringed by making, using, selling, offering for
 sale, or importing the Program or any portion of it.
 
   11. Patents.


### PR DESCRIPTION
Closes #158 